### PR TITLE
Fix name spelling Rose -> Rost

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -765,8 +765,8 @@ hcl_palettes("diverging", plot = TRUE)
 - [Colorspace by Zeileis et al]()
 - [Colorspace talk by Achim Zeileis]()
 - http://hclwizard.org/
-- [How your colorblind and colorweak readers see your colors](https://blog.datawrapper.de/colorblindness-part1/) by [Lisa Charlotte Rose](Part 1 of 3)
-- [What to consider when visualizing data for colorblind readers](https://blog.datawrapper.de/colorblindness-part2/) by [Lisa Charlotte Rose](Part 2 of 3)
+- [How your colorblind and colorweak readers see your colors](https://blog.datawrapper.de/colorblindness-part1/) by [Lisa Charlotte Rost](https://lisacharlotterost.de/)
+- [What to consider when visualizing data for colorblind readers](https://blog.datawrapper.de/colorblindness-part2/) by [Lisa Charlotte Rost](https://lisacharlotterost.de/)
 ]
 
 ---


### PR DESCRIPTION
Also replaced URL for the author since previous one wasn't a real URL (though I may be unaware of some special syntax at play)